### PR TITLE
Move class saving to disable

### DIFF
--- a/lib/json_api_client_mock/resource_extensions.rb
+++ b/lib/json_api_client_mock/resource_extensions.rb
@@ -4,7 +4,6 @@ module JsonApiClientMock
 
     included do
       class_attribute :original_connection_class
-      self.original_connection_class = self.connection_class
       self.disable_net_connect!
     end
 
@@ -22,6 +21,7 @@ module JsonApiClientMock
       end
 
       def disable_net_connect!
+        self.original_connection_class = self.connection_class
         self.connection_class = MockConnection
       end
     end


### PR DESCRIPTION
This means if you override the Connection after the gem is loaded, then
call disable_net_connect!, your override is saved.
