### PR TITLE
support param-less .find queries

### DIFF
--- a/lib/json_api_client_mock/mock_connection.rb
+++ b/lib/json_api_client_mock/mock_connection.rb
@@ -36,13 +36,14 @@ module JsonApiClientMock
     end
 
     def find_test_results(query)
-      class_mocks(query).detect{|mock| mock[:conditions] == query.params} ||
-        class_mocks(query).detect{|mock| mock[:conditions].nil?}
+      class_mocks(query).detect { |mock| mock[:conditions] == query.params } ||
+        class_mocks(query).detect { |mock| mock[:conditions] && (mock[:conditions][:path] == query.path) } ||
+          class_mocks(query).detect { |mock| mock[:conditions].nil? }
     end
 
     def missing_message(query)
-      ["no test results set for #{query.klass.name} with conditions: #{query.params.pretty_inspect}",
-        "mocks conditions available: #{class_mocks(query).map {|m| m[:conditions]}.pretty_inspect}"].join("\n\n")
+      ["no test results set for #{query.klass.name} with conditions: #{query.params.pretty_inspect} or for request path #{query.path}",
+        "mocks conditions available: #{class_mocks(query).map { |m| m[:conditions] }.pretty_inspect}"].join("\n\n")
     end
   end
 end

--- a/test/json_api_client_mock_test.rb
+++ b/test/json_api_client_mock_test.rb
@@ -50,6 +50,21 @@ class JsonApiClientMockTest < MiniTest::Unit::TestCase
     assert_equal('asdf', first.qwer)
   end
 
+  def test_by_conditional_request_path_mocking
+    BarResource.set_test_results([{foo: 'bar', qwer: 'asdf'}], {path: 'bar_resources/10'})
+    assert_raises(JsonApiClientMock::MissingMock) do
+      BarResource.all
+    end
+
+    results = BarResource.find(10)
+    assert_equal(1, results.length)
+
+    first = results.first
+    assert_equal(BarResource, first.class)
+    assert_equal('bar', first.foo)
+    assert_equal('asdf', first.qwer)
+  end
+
   def test_conditional_mocking_param_order
     BarResource.set_test_results([{foo: 'bar', qwer: 'asdf'}], {foo: 'bar', qwer: 'asdf'})
 


### PR DESCRIPTION
doing a simple Foo::Bar.find(n) doesn't send in any query parameters that can be checked against pre-set conditions. This compares any "path" condition to the query path, which contains _n_ where _n_ is the lookup id.