### PR TITLE
Autogeneration object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,5 @@ gemspec
 
 gem 'rake', '~> 0'
 
-group :test do
-  gem 'pry'
-end
 # gem 'json_api_client'
 # gem 'json_api_client', :path => '~/code/gems/rails3/json_api_client'

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake', '~> 0'
+
+group :test do
+  gem 'pry'
+end
 # gem 'json_api_client'
 # gem 'json_api_client', :path => '~/code/gems/rails3/json_api_client'


### PR DESCRIPTION
We'd like to have a hook into json_api_client_mock so if we didn't explicitly set up conditions and responses, we could default to an object that will return any json we choose.  

The use case is handing the query with the class name and deriving the Contact endpoint to generate json based off the contract(randomly).

This could greatly alleviate the associated data setup required for testing as well has holding those results we generate to use later in the tests
